### PR TITLE
[FEAT] 유저 정보 제외한 나머지 요소들로 복장 추천 알고리즘 구현

### DIFF
--- a/article1_be/article1-be/src/main/java/article1be/outfit/controller/OutfitController.java
+++ b/article1_be/article1-be/src/main/java/article1be/outfit/controller/OutfitController.java
@@ -1,0 +1,27 @@
+package article1be.outfit.controller;
+
+import article1be.outfit.dto.OutfitResponseDTO;
+import article1be.outfit.dto.OutfitRequestDTO;
+import article1be.outfit.entity.OutfitCategory;
+import article1be.outfit.service.OutfitService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/user/outfit")
+@RequiredArgsConstructor
+public class OutfitController {
+
+    private final OutfitService outfitService;
+
+    @PostMapping("/recommendations")
+    public ResponseEntity<Map<OutfitCategory, List<OutfitResponseDTO>>> getTop3OutfitByCategory(@RequestBody OutfitRequestDTO requestDTO) throws IOException {
+        Map<OutfitCategory, List<OutfitResponseDTO>> result = outfitService.getRecommendedOutfits(requestDTO);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/article1_be/article1-be/src/main/java/article1be/outfit/dto/OutfitRequestDTO.java
+++ b/article1_be/article1-be/src/main/java/article1be/outfit/dto/OutfitRequestDTO.java
@@ -1,0 +1,15 @@
+package article1be.outfit.dto;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OutfitRequestDTO {
+    private Long userSeq;
+    private Long situationSeq;
+    private LocalDateTime requestedAt;   // 추천받을 날짜와 시간
+    private double latitude; // 위도
+    private double longitude; //경도
+}

--- a/article1_be/article1-be/src/main/java/article1be/outfit/dto/OutfitResponseDTO.java
+++ b/article1_be/article1-be/src/main/java/article1be/outfit/dto/OutfitResponseDTO.java
@@ -1,0 +1,11 @@
+package article1be.outfit.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OutfitResponseDTO {
+    private String outfitName;
+    private String outfitImg;
+}

--- a/article1_be/article1-be/src/main/java/article1be/outfit/entity/Outfit.java
+++ b/article1_be/article1-be/src/main/java/article1be/outfit/entity/Outfit.java
@@ -1,0 +1,42 @@
+package article1be.outfit.entity;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "outfit")
+@ToString
+public class Outfit {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long outfitSeq;
+
+    private String outfitName;
+
+    private Integer outfitWeather; // 악세사리 외에는 null
+
+    private Double outfitTempMax;
+
+    private Double outfitTempMin;
+
+    private String outfitImg;
+
+    @Enumerated(EnumType.STRING)
+    private OutfitGender outfitGender; // 악세사리는 null
+
+    @Enumerated(EnumType.STRING)
+    private OutfitLevel outfitLevel; // 악세사리 외에는 null
+
+    @Enumerated(EnumType.STRING)
+    private OutfitCategory outfitCategory;
+
+
+
+}

--- a/article1_be/article1-be/src/main/java/article1be/outfit/entity/OutfitCategory.java
+++ b/article1_be/article1-be/src/main/java/article1be/outfit/entity/OutfitCategory.java
@@ -1,0 +1,18 @@
+package article1be.outfit.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum OutfitCategory {
+
+    TOP("상의"),
+    BOTTOM("하의"),
+    OUTERWEAR("아우터"),
+    SHOES("신발"),
+    ACCESSORY("악세서리");
+
+    private final String category;
+
+    OutfitCategory(String category) {this.category = category;}
+
+}

--- a/article1_be/article1-be/src/main/java/article1be/outfit/entity/OutfitGender.java
+++ b/article1_be/article1-be/src/main/java/article1be/outfit/entity/OutfitGender.java
@@ -1,0 +1,16 @@
+package article1be.outfit.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum OutfitGender {
+    M("남성용"),
+    F("여성용"),
+    N("성별무관");
+
+    private final String gender;
+
+    OutfitGender(String gender) {
+        this.gender = gender;
+    }
+}

--- a/article1_be/article1-be/src/main/java/article1be/outfit/entity/OutfitLevel.java
+++ b/article1_be/article1-be/src/main/java/article1be/outfit/entity/OutfitLevel.java
@@ -1,0 +1,17 @@
+package article1be.outfit.entity;
+
+
+import lombok.Getter;
+
+@Getter
+public enum OutfitLevel {
+    REQUIRED("필수"),
+    RECOMMENDED("권장"),
+    SELECTION("선택");
+
+
+   private final String level;
+
+   OutfitLevel(String level) {this.level = level;}
+
+}

--- a/article1_be/article1-be/src/main/java/article1be/outfit/entity/OutfitSituation.java
+++ b/article1_be/article1-be/src/main/java/article1be/outfit/entity/OutfitSituation.java
@@ -1,0 +1,32 @@
+package article1be.outfit.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "outfit_situation")
+@ToString
+public class OutfitSituation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long outfitSituationSeq;
+
+    @ManyToOne
+    @JoinColumn(name = "outfit_seq", nullable = false)
+    private Outfit outfit;
+
+    @ManyToOne
+    @JoinColumn(name = "situation_seq", nullable = false)
+    private Situation situation;
+
+    public OutfitSituation(Outfit outfit, Situation situation) {
+        this.outfit = outfit;
+        this.situation = situation;
+    }
+}

--- a/article1_be/article1-be/src/main/java/article1be/outfit/entity/OutfitStyle.java
+++ b/article1_be/article1-be/src/main/java/article1be/outfit/entity/OutfitStyle.java
@@ -1,0 +1,32 @@
+package article1be.outfit.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "outfit_style")
+@ToString
+public class OutfitStyle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long selectStyleSeq;
+
+    @ManyToOne
+    @JoinColumn(name = "outfit_seq", nullable = false)
+    private Outfit outfit;
+
+    @ManyToOne
+    @JoinColumn(name = "style_seq", nullable = false)
+    private Style style;
+
+    public OutfitStyle(Outfit outfit, Style style) {
+        this.outfit = outfit;
+        this.style = style;
+    }
+}

--- a/article1_be/article1-be/src/main/java/article1be/outfit/entity/Situation.java
+++ b/article1_be/article1-be/src/main/java/article1be/outfit/entity/Situation.java
@@ -1,0 +1,19 @@
+package article1be.outfit.entity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "situation")
+@ToString
+public class Situation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long situationSeq;
+
+    private String situationName;
+}

--- a/article1_be/article1-be/src/main/java/article1be/outfit/entity/Style.java
+++ b/article1_be/article1-be/src/main/java/article1be/outfit/entity/Style.java
@@ -1,0 +1,18 @@
+package article1be.outfit.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "style")
+public class Style {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long styleSeq;
+
+    private String styleName;
+}

--- a/article1_be/article1-be/src/main/java/article1be/outfit/repository/OutfitRepository.java
+++ b/article1_be/article1-be/src/main/java/article1be/outfit/repository/OutfitRepository.java
@@ -1,0 +1,27 @@
+package article1be.outfit.repository;
+
+import article1be.outfit.entity.Outfit;
+import article1be.outfit.entity.OutfitCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface OutfitRepository extends JpaRepository<Outfit, Long> {
+
+    //최고 온도: 19.030000686645508
+    //최저 온도: 14.890000343322754
+    // 기존의 카테고리와 날씨 조건으로 옷을 조회하는 메서드
+    @Query("SELECT o FROM Outfit o WHERE o.outfitCategory = :category " +
+            "AND o.outfitTempMin <= :minTemp AND o.outfitTempMax >= :maxTemp " +
+            "AND (o.outfitWeather = :weatherCode OR o.outfitWeather IS NULL)")
+    List<Outfit> findByCategoryAndWeatherConditions(
+            @Param("category") OutfitCategory category,
+            @Param("minTemp") double minTemp,
+            @Param("maxTemp") double maxTemp,
+            @Param("weatherCode") int weatherCode);
+
+}

--- a/article1_be/article1-be/src/main/java/article1be/outfit/repository/OutfitSituationRepository.java
+++ b/article1_be/article1-be/src/main/java/article1be/outfit/repository/OutfitSituationRepository.java
@@ -1,0 +1,8 @@
+package article1be.outfit.repository;
+
+import article1be.outfit.entity.OutfitSituation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OutfitSituationRepository extends JpaRepository<OutfitSituation, Long> {
+    boolean existsByOutfit_OutfitSeqAndSituation_SituationSeq(Long outfitSeq, Long situationSeq);
+}

--- a/article1_be/article1-be/src/main/java/article1be/outfit/repository/OutfitStyleRepository.java
+++ b/article1_be/article1-be/src/main/java/article1be/outfit/repository/OutfitStyleRepository.java
@@ -1,0 +1,8 @@
+package article1be.outfit.repository;
+
+import article1be.outfit.entity.OutfitStyle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OutfitStyleRepository extends JpaRepository<OutfitStyle, Long> {
+    boolean existsByOutfit_OutfitSeqAndStyle_StyleSeq(Long outfitSeq, Long styleSeq);
+}

--- a/article1_be/article1-be/src/main/java/article1be/outfit/service/OutfitService.java
+++ b/article1_be/article1-be/src/main/java/article1be/outfit/service/OutfitService.java
@@ -1,0 +1,115 @@
+package article1be.outfit.service;
+
+import article1be.openweather.dto.ResponseTodayDTO;
+import article1be.openweather.service.OpenWeatherService;
+import article1be.outfit.dto.OutfitRequestDTO;
+import article1be.outfit.dto.OutfitResponseDTO;
+import article1be.outfit.entity.Outfit;
+import article1be.outfit.entity.OutfitCategory;
+import article1be.outfit.repository.OutfitRepository;
+import article1be.outfit.repository.OutfitSituationRepository;
+import article1be.outfit.repository.OutfitStyleRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+public class OutfitService {
+    private final OpenWeatherService weatherService;
+    private final OutfitRepository outfitRepository; // Outfit 데이터를 가져오는 Repository
+    private final OutfitSituationRepository outfitSituationRepository;
+    private final OutfitStyleRepository outfitStyleRepository;
+
+    @Autowired
+    public OutfitService(OpenWeatherService weatherService, OutfitRepository outfitRepository, OutfitSituationRepository outfitSituationRepository, OutfitStyleRepository outfitStyleRepository) {
+        this.weatherService = weatherService;
+        this.outfitRepository = outfitRepository;
+        this.outfitSituationRepository = outfitSituationRepository;
+        this.outfitStyleRepository = outfitStyleRepository;
+
+    }
+
+    public  Map<OutfitCategory, List<OutfitResponseDTO>> getRecommendedOutfits(OutfitRequestDTO requestDTO) throws UnsupportedEncodingException, UnsupportedEncodingException {
+
+        // 1. 날씨 데이터 가져오기 - 날짜,시간이 적용될 수 있도록 수정되어야 할듯.
+        ResponseTodayDTO weatherData = weatherService.getTodayWeatherData(String.valueOf(requestDTO.getLatitude()), String.valueOf(requestDTO.getLongitude()));
+
+        if (weatherData == null) {
+            throw new IllegalStateException("날씨 정보를 가져올 수 없습니다.");
+        }
+
+        // 날씨 데이터에서 필요한 정보 추출
+        double maxTemp = weatherData.getHighTemp();
+        double minTemp = weatherData.getLowTemp();
+        int airQuality = weatherData.getAqi();
+        int weatherCode = weatherData.getList().get(0).getWeather().get(0).getId(); // 임시로 첫 번째 날씨 코드 사용
+        log.info("최고 온도: "+ maxTemp);
+        log.info("최저 온도: "+ minTemp);
+        log.info("공기질: "+airQuality);
+        log.info("날씨코드: "+weatherCode);
+
+        // 회원의 이전 선택 기록을 가져와서 점수 계산에 활용 - user 구현 후 적용
+        /*Set<Long> previouslyChosenOutfitIds = userPreferenceRepository.findPreviouslyChosenOutfitIdsByUser(userSeq);*/
+
+        // 회원의 선호 style - user 구현 후 적용
+        // Long styleSeq = preferenceRepository.findStyleSeqByUserSeq(userSeq);
+
+        // test 위한 임시 styleSeq 지정
+        long styleSeq = 1;
+
+        // 4. 각 옷에 점수를 매기고 카테고리별로 상위 3개씩 추출
+        Map<OutfitCategory, List<OutfitResponseDTO>> recommendedOutfits = new HashMap<>();
+        for (OutfitCategory outfitCategory : OutfitCategory.values()) {
+            //날씨 정보에 맞는 옷만 필터링
+            log.info("카테고리 :"+outfitCategory);
+            List<Outfit> outfits = outfitRepository.findByCategoryAndWeatherConditions(outfitCategory,minTemp,maxTemp,weatherCode);
+            log.info("outfit들: "+outfits+"\n");
+            //필터링된 옷들에 대해 점수를 계산하고 내림차순으로 정렬, 상위 3개만 return.
+            List<OutfitResponseDTO> topOutfits = outfits.stream()
+                    .sorted((o1, o2) -> Integer.compare(
+                            calculateScore(o2, requestDTO.getSituationSeq(), styleSeq/*, previouslyChosenOutfitIds*/),
+                            calculateScore(o1, requestDTO.getSituationSeq(), styleSeq/*, previouslyChosenOutfitIds*/)
+                    ))
+                    .limit(3)
+                    .map(outfit -> new OutfitResponseDTO(outfit.getOutfitName(), outfit.getOutfitImg()))
+                    .collect(Collectors.toList());
+
+            recommendedOutfits.put(outfitCategory, topOutfits);
+        }
+
+        return recommendedOutfits;
+
+    }
+
+    // 각 옷에 점수를 매기는 메서드
+    private int calculateScore(Outfit outfit, Long situationSeq , Long styleSeq/*, Set<Long> previouslyChosenOutfitIds*/) {
+        int score = 0;
+
+        // 상황에 맞는 옷에 점수 추가
+        if (outfitSituationRepository.existsByOutfit_OutfitSeqAndSituation_SituationSeq(outfit.getOutfitSeq(), situationSeq)) {
+            score += 10;
+        }
+
+        // 회원의 스타일에 맞는 옷에 점수 추가
+        if (outfitStyleRepository.existsByOutfit_OutfitSeqAndStyle_StyleSeq(outfit.getOutfitSeq(), styleSeq)) {
+            score += 5;
+        }
+
+        // 회원이 이전에 선택한 옷에 추가 점수
+        /*if (previouslyChosenOutfitIds.contains(outfit.getOutfitSeq())) {
+            score += 3;
+        }*/
+
+        return score;
+    }
+
+
+}

--- a/article1_be/article1-be/src/main/resources/Schema.sql
+++ b/article1_be/article1-be/src/main/resources/Schema.sql
@@ -1,20 +1,22 @@
-DROP TABLE IF EXISTS BLAME;
-DROP TABLE IF EXISTS REVIEW;
-DROP TABLE IF EXISTS REPLY;
-DROP TABLE IF EXISTS PICTURE;
-DROP TABLE IF EXISTS SELECT_CLOTHING;
-DROP TABLE IF EXISTS OUTFIT_STYLE;
-DROP TABLE IF EXISTS OUTFIT_SITUATION;
-DROP TABLE IF EXISTS SELECT_RECORD;
-DROP TABLE IF EXISTS BOARD;
-DROP TABLE IF EXISTS OUTFIT;
-DROP TABLE IF EXISTS STYLE;
-DROP TABLE IF EXISTS SITUATION;
-DROP TABLE IF EXISTS PREFERENCE;
-DROP TABLE IF EXISTS BAN;
-DROP TABLE IF EXISTS USER;
+DROP TABLE IF EXISTS blame;
+DROP TABLE IF EXISTS review;
+DROP TABLE IF EXISTS reply;
+DROP TABLE IF EXISTS picture;
+DROP TABLE IF EXISTS select_outfit;
+DROP TABLE IF EXISTS outfit_style;
+DROP TABLE IF EXISTS outfit_situation;
+DROP TABLE IF EXISTS board;
+DROP TABLE IF EXISTS style;
+DROP TABLE IF EXISTS preference;
+DROP TABLE IF EXISTS ban;
+DROP TABLE IF EXISTS select_record;
+DROP TABLE IF EXISTS situation;
+DROP TABLE IF EXISTS outfit;
+DROP TABLE IF EXISTS user;
 
-CREATE TABLE USER (
+ALTER DATABASE article CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE user (
                       user_seq BIGINT NOT NULL AUTO_INCREMENT,
                       user_social_site VARCHAR(50) NOT NULL COMMENT 'KAKAO, NAVER, GOOGLE',
                       user_id VARCHAR(255) NOT NULL,
@@ -30,14 +32,14 @@ CREATE TABLE USER (
                       PRIMARY KEY (user_seq)
 );
 
-CREATE TABLE PREFERENCE (
+CREATE TABLE preference (
                             user_seq BIGINT NOT NULL AUTO_INCREMENT,
                             preference_condition VARCHAR(50) NOT NULL DEFAULT 'NORMAL' COMMENT 'HOT, COLD, NORMAL',
                             preference_style VARCHAR(50) NOT NULL DEFAULT 'NORMAL' COMMENT 'CASUAL, SPORTY, FORMAL, NORMAL',
                             PRIMARY KEY (user_seq)
 );
 
-CREATE TABLE OUTFIT (
+CREATE TABLE outfit (
                         outfit_seq BIGINT NOT NULL AUTO_INCREMENT,
                         outfit_name VARCHAR(50) NOT NULL,
                         outfit_weather INT NULL COMMENT '악세서리만',
@@ -50,19 +52,19 @@ CREATE TABLE OUTFIT (
                         PRIMARY KEY (outfit_seq)
 );
 
-CREATE TABLE STYLE (
+CREATE TABLE style (
                        style_seq BIGINT NOT NULL AUTO_INCREMENT,
                        style_name VARCHAR(50) NOT NULL COMMENT '캐주얼, 포멀, 스포티',
                        PRIMARY KEY (style_seq)
 );
 
-CREATE TABLE SITUATION (
+CREATE TABLE situation (
                            situation_seq BIGINT NOT NULL AUTO_INCREMENT,
                            situation_name VARCHAR(50) NOT NULL COMMENT '일상, 여행, 운동, 데이트, 격식있는자리',
                            PRIMARY KEY (situation_seq)
 );
 
-CREATE TABLE SELECT_RECORD (
+CREATE TABLE select_record (
                                select_seq BIGINT NOT NULL AUTO_INCREMENT,
                                user_seq BIGINT NOT NULL,
                                situation_seq BIGINT NOT NULL,
@@ -78,7 +80,7 @@ CREATE TABLE SELECT_RECORD (
                                PRIMARY KEY (select_seq)
 );
 
-CREATE TABLE BOARD (
+CREATE TABLE board (
                        board_seq BIGINT NOT NULL AUTO_INCREMENT,
                        user_seq BIGINT NOT NULL,
                        board_title VARCHAR(50) NOT NULL,
@@ -91,7 +93,7 @@ CREATE TABLE BOARD (
                        PRIMARY KEY (board_seq)
 );
 
-CREATE TABLE REVIEW (
+CREATE TABLE review (
                         review_seq BIGINT NOT NULL,
                         user_seq BIGINT NOT NULL,
                         select_seq BIGINT NOT NULL,
@@ -107,7 +109,7 @@ CREATE TABLE REVIEW (
                         PRIMARY KEY (review_seq, user_seq)
 );
 
-CREATE TABLE BLAME (
+CREATE TABLE blame (
                        blame_seq BIGINT NOT NULL AUTO_INCREMENT,
                        blame_user_seq BIGINT NOT NULL,
                        blame_board_seq BIGINT NULL,
@@ -120,7 +122,7 @@ CREATE TABLE BLAME (
                        PRIMARY KEY (blame_seq)
 );
 
-CREATE TABLE REPLY (
+CREATE TABLE reply (
                        reply_seq BIGINT NOT NULL AUTO_INCREMENT,
                        board_seq BIGINT NOT NULL,
                        reply_user_seq BIGINT NOT NULL,
@@ -131,7 +133,7 @@ CREATE TABLE REPLY (
                        PRIMARY KEY (reply_seq)
 );
 
-CREATE TABLE PICTURE (
+CREATE TABLE picture (
                          picture_seq BIGINT NOT NULL AUTO_INCREMENT,
                          picture_board_seq BIGINT NOT NULL,
                          picture_originename VARCHAR(255) NOT NULL,
@@ -144,28 +146,28 @@ CREATE TABLE PICTURE (
                          PRIMARY KEY (picture_seq)
 );
 
-CREATE TABLE SELECT_CLOTHING (
-                                 select_clothing_seq BIGINT NOT NULL AUTO_INCREMENT,
+CREATE TABLE select_outfit (
+                                 select_outfit_seq BIGINT NOT NULL AUTO_INCREMENT,
                                  outfit_seq BIGINT NOT NULL,
                                  select_seq BIGINT NOT NULL,
-                                 PRIMARY KEY (select_clothing_seq)
+                                 PRIMARY KEY (select_outfit_seq)
 );
 
-CREATE TABLE OUTFIT_STYLE (
+CREATE TABLE outfit_style (
                               select_style_seq BIGINT NOT NULL AUTO_INCREMENT,
                               style_seq BIGINT NOT NULL,
                               outfit_seq BIGINT NOT NULL,
                               PRIMARY KEY (select_style_seq)
 );
 
-CREATE TABLE OUTFIT_SITUATION (
+CREATE TABLE outfit_situation (
                                   outfit_situation_seq BIGINT NOT NULL AUTO_INCREMENT,
                                   outfit_seq BIGINT NOT NULL,
                                   situation_seq BIGINT NOT NULL,
                                   PRIMARY KEY (outfit_situation_seq)
 );
 
-CREATE TABLE BAN (
+CREATE TABLE ban (
                      ban_seq BIGINT NOT NULL AUTO_INCREMENT,
                      ban_user_seq BIGINT NOT NULL,
                      ban_startdate DATETIME NOT NULL DEFAULT LOCALTIME,
@@ -175,22 +177,22 @@ CREATE TABLE BAN (
 );
 
 
-ALTER TABLE PREFERENCE ADD CONSTRAINT FK_user_TO_PREFERENCE_1 FOREIGN KEY (user_seq) REFERENCES USER (user_seq);
-ALTER TABLE SELECT_RECORD ADD CONSTRAINT FK_user_TO_SELECT_RECORD FOREIGN KEY (user_seq) REFERENCES USER (user_seq);
-ALTER TABLE SELECT_RECORD ADD CONSTRAINT FK_situation_TO_SELECT_RECORD FOREIGN KEY (situation_seq) REFERENCES SITUATION (situation_seq);
-ALTER TABLE BOARD ADD CONSTRAINT FK_user_TO_BOARD FOREIGN KEY (user_seq) REFERENCES USER (user_seq);
-ALTER TABLE REVIEW ADD CONSTRAINT FK_user_TO_REVIEW FOREIGN KEY (user_seq) REFERENCES USER (user_seq);
-ALTER TABLE REVIEW ADD CONSTRAINT FK_select_TO_REVIEW FOREIGN KEY (select_seq) REFERENCES SELECT_RECORD (select_seq);
-ALTER TABLE BLAME ADD CONSTRAINT FK_user_TO_BLAME FOREIGN KEY (blame_user_seq) REFERENCES USER (user_seq);
-ALTER TABLE BLAME ADD CONSTRAINT FK_board_TO_BLAME FOREIGN KEY (blame_board_seq) REFERENCES BOARD (board_seq);
-ALTER TABLE BLAME ADD CONSTRAINT FK_review_TO_BLAME FOREIGN KEY (blame_review_seq) REFERENCES REVIEW (review_seq);
-ALTER TABLE REPLY ADD CONSTRAINT FK_board_TO_REPLY FOREIGN KEY (board_seq) REFERENCES BOARD (board_seq);
-ALTER TABLE REPLY ADD CONSTRAINT FK_user_TO_REPLY FOREIGN KEY (reply_user_seq) REFERENCES USER (user_seq);
-ALTER TABLE PICTURE ADD CONSTRAINT FK_board_TO_PICTURE FOREIGN KEY (picture_board_seq) REFERENCES BOARD (board_seq);
-ALTER TABLE SELECT_CLOTHING ADD CONSTRAINT FK_outfit_TO_SELECT_CLOTHING FOREIGN KEY (outfit_seq) REFERENCES OUTFIT (outfit_seq);
-ALTER TABLE SELECT_CLOTHING ADD CONSTRAINT FK_select_TO_SELECT_CLOTHING FOREIGN KEY (select_seq) REFERENCES SELECT_RECORD (select_seq);
-ALTER TABLE OUTFIT_STYLE ADD CONSTRAINT FK_style_TO_OUTFIT_STYLE FOREIGN KEY (style_seq) REFERENCES STYLE (style_seq);
-ALTER TABLE OUTFIT_STYLE ADD CONSTRAINT FK_outfit_TO_OUTFIT_STYLE FOREIGN KEY (outfit_seq) REFERENCES OUTFIT (outfit_seq);
-ALTER TABLE OUTFIT_SITUATION ADD CONSTRAINT FK_outfit_TO_OUTFIT_SITUATION FOREIGN KEY (outfit_seq) REFERENCES OUTFIT (outfit_seq);
-ALTER TABLE OUTFIT_SITUATION ADD CONSTRAINT FK_situation_TO_OUTFIT_SITUATION FOREIGN KEY (situation_seq) REFERENCES SITUATION (situation_seq);
-ALTER TABLE BAN ADD CONSTRAINT FK_user_TO_BAN FOREIGN KEY (ban_user_seq) REFERENCES USER (user_seq);
+ALTER TABLE preference ADD CONSTRAINT FK_user_TO_preference FOREIGN KEY (user_seq) REFERENCES user (user_seq);
+ALTER TABLE select_record ADD CONSTRAINT FK_user_TO_select_record FOREIGN KEY (user_seq) REFERENCES user (user_seq);
+ALTER TABLE select_record ADD CONSTRAINT FK_situation_TO_select_record FOREIGN KEY (situation_seq) REFERENCES situation (situation_seq);
+ALTER TABLE board ADD CONSTRAINT FK_user_TO_board FOREIGN KEY (user_seq) REFERENCES user (user_seq);
+ALTER TABLE review ADD CONSTRAINT FK_user_TO_review FOREIGN KEY (user_seq) REFERENCES user (user_seq);
+ALTER TABLE review ADD CONSTRAINT FK_select_TO_review FOREIGN KEY (select_seq) REFERENCES select_record (select_seq);
+ALTER TABLE blame ADD CONSTRAINT FK_user_TO_blame FOREIGN KEY (blame_user_seq) REFERENCES user (user_seq);
+ALTER TABLE blame ADD CONSTRAINT FK_board_TO_blame FOREIGN KEY (blame_board_seq) REFERENCES board (board_seq);
+ALTER TABLE blame ADD CONSTRAINT FK_review_TO_blame FOREIGN KEY (blame_review_seq) REFERENCES review (review_seq);
+ALTER TABLE reply ADD CONSTRAINT FK_board_TO_reply FOREIGN KEY (board_seq) REFERENCES board (board_seq);
+ALTER TABLE reply ADD CONSTRAINT FK_user_TO_reply FOREIGN KEY (reply_user_seq) REFERENCES user (user_seq);
+ALTER TABLE picture ADD CONSTRAINT FK_board_TO_picture FOREIGN KEY (picture_board_seq) REFERENCES board (board_seq);
+ALTER TABLE select_outfit ADD CONSTRAINT FK_outfit_TO_select_outfit FOREIGN KEY (outfit_seq) REFERENCES outfit (outfit_seq);
+ALTER TABLE select_outfit ADD CONSTRAINT FK_select_TO_select_outfit FOREIGN KEY (select_seq) REFERENCES select_record (select_seq);
+ALTER TABLE outfit_style ADD CONSTRAINT FK_style_TO_outfit_style FOREIGN KEY (style_seq) REFERENCES style (style_seq);
+ALTER TABLE outfit_style ADD CONSTRAINT FK_outfit_TO_outfit_style FOREIGN KEY (outfit_seq) REFERENCES outfit (outfit_seq);
+ALTER TABLE outfit_situation ADD CONSTRAINT FK_outfit_TO_outfit_situation FOREIGN KEY (outfit_seq) REFERENCES outfit (outfit_seq);
+ALTER TABLE outfit_situation ADD CONSTRAINT FK_situation_TO_outfit_situation FOREIGN KEY (situation_seq) REFERENCES situation (situation_seq);
+ALTER TABLE ban ADD CONSTRAINT FK_user_TO_ban FOREIGN KEY (ban_user_seq) REFERENCES user (user_seq);

--- a/article1_be/article1-be/src/main/resources/data.sql
+++ b/article1_be/article1-be/src/main/resources/data.sql
@@ -1,0 +1,184 @@
+INSERT INTO outfit (outfit_name, outfit_weather, outfit_temp_max, outfit_temp_min, outfit_category, outfit_gender, outfit_level, outfit_img) VALUES
+-- 상의
+('맨투맨', NULL, 20, -100, 'TOP', 'N', NULL, 'example.com/image1.jpg'),
+('반팔_티셔츠', NULL, 100, 20, 'TOP', 'N', NULL, 'example.com/image2.jpg'),
+('셔츠', NULL, 25, 15, 'TOP', 'N', NULL, 'example.com/image3.jpg'),
+('반팔셔츠', NULL, 20, 100, 'TOP', 'N', NULL, 'example.com/image4.jpg'),
+('린넨셔츠', NULL, 20, 100, 'TOP', 'N', NULL, 'example.com/image5.jpg'),
+('니트_스웨터', NULL, 15, -100, 'TOP', 'N', NULL, 'example.com/image6.jpg'),
+('후드티', NULL, 18, 8, 'TOP', 'N', NULL, 'example.com/image7.jpg'),
+('폴로_반팔티', NULL, 28, 18, 'TOP', 'M', NULL, 'example.com/image8.jpg'),
+('나시', NULL, 35, 25, 'TOP', 'N', NULL, 'example.com/image9.jpg'),
+('터틀넥_스웨터', NULL, 12, 0, 'TOP', 'N', NULL, 'example.com/image10.jpg'),
+('블라우스', NULL, 25, 15, 'TOP', 'F', NULL, 'example.com/image11.jpg'),
+
+-- 하의
+('긴청바지', NULL, 25, 10, 'BOTTOM', 'N', NULL, 'example.com/image12.jpg'),
+('긴면바지', NULL, 30, 15, 'BOTTOM', 'M', NULL, 'example.com/image13.jpg'),
+('반바지', NULL, 35, 20, 'BOTTOM', 'N', NULL, 'example.com/image14.jpg'),
+('슬랙스', NULL, 28, 18, 'BOTTOM', 'N', NULL, 'example.com/image15.jpg'),
+('트레이닝_팬츠', NULL, 20, 5, 'BOTTOM', 'N', NULL, 'example.com/image16.jpg'),
+('조거_팬츠', NULL, 18, 8, 'BOTTOM', 'N', NULL, 'example.com/image17.jpg'),
+('와이드_팬츠', NULL, 25, 15, 'BOTTOM', 'N', NULL, 'example.com/image18.jpg'),
+('스키니_진', NULL, 22, 12, 'BOTTOM', 'F', NULL, 'example.com/image19.jpg'),
+('스커트', NULL, 30, 20, 'BOTTOM', 'F', NULL, 'example.com/image20.jpg'),
+('롱_스커트', NULL, 28, 18, 'BOTTOM', 'F', NULL, 'example.com/image21.jpg'),
+
+-- 아우터
+('자켓', NULL, 15, 5, 'OUTERWEAR', 'N', NULL, 'example.com/image22.jpg'),
+('코트', NULL, 15, -10, 'OUTERWEAR', 'N', NULL, 'example.com/image23.jpg'),
+('패딩', NULL, 10, -100, 'OUTERWEAR', 'N', NULL, 'example.com/image24.jpg'),
+('후드_집업', NULL, 20, 10, 'OUTERWEAR', 'N', NULL, 'example.com/image25.jpg'),
+('트렌치코트', NULL, 20, 8, 'OUTERWEAR', 'N', NULL, 'example.com/image26.jpg'),
+('무스탕', NULL, 12, -3, 'OUTERWEAR', 'N', NULL, 'example.com/image27.jpg'),
+('경량_패딩', NULL, 15, 0, 'OUTERWEAR', 'N', NULL, 'example.com/image28.jpg'),
+('바람막이', NULL, 20, 10, 'OUTERWEAR', 'N', NULL, 'example.com/image29.jpg'),
+('얇은_가디건', NULL, 25, 15, 'OUTERWEAR', 'N', NULL, 'example.com/image30.jpg'),
+
+-- 신발
+('운동화', NULL, 30, -10, 'SHOES', 'N', NULL, 'example.com/image31.jpg'),
+('슬리퍼', NULL, 100, 20, 'SHOES', 'N', NULL, 'example.com/image32.jpg'),
+('부츠', NULL, 15, -10, 'SHOES', 'N', NULL, 'example.com/image33.jpg'),
+('샌들', NULL, 100, 20, 'SHOES', 'N', NULL, 'example.com/image34.jpg'),
+('로퍼', NULL, 25, -5, 'SHOES', 'N', NULL, 'example.com/image35.jpg'),
+('워커', NULL, 25, -5, 'SHOES', 'N', NULL, 'example.com/image36.jpg'),
+('플랫슈즈', NULL, 30, 0, 'SHOES', 'F', NULL, 'example.com/image37.jpg'),
+('하이힐', NULL, 30, 0, 'SHOES', 'F', NULL, 'example.com/image38.jpg'),
+('발목_부츠', NULL, 20, -20, 'SHOES', 'N', NULL, 'example.com/image39.jpg'),
+('스니커즈', NULL, 30, -10, 'SHOES', 'N', NULL, 'example.com/image40.jpg'),
+('크록스', NULL, 100, 20, 'SHOES', 'N', NULL, 'example.com/image41.jpg'),
+
+-- 악세사리
+('선글라스', 800, 100, 15, 'ACCESSORY', 'N', 'RECOMMENDED', 'example.com/image42.jpg'),
+('넥워머', 801, 10, -100, 'ACCESSORY', 'N', 'RECOMMENDED', 'example.com/image43.jpg'),
+('귀마개', 801, 10, -100, 'ACCESSORY', 'N', 'RECOMMENDED', 'example.com/image44.jpg'),
+('썬캡', 800, 35, 20, 'ACCESSORY', 'N', 'RECOMMENDED', 'example.com/image45.jpg'),
+('장갑', 801, 5, -100, 'ACCESSORY', 'N', 'RECOMMENDED', 'example.com/image46.jpg'),
+('귀도리', 801, 10, -5, 'ACCESSORY', 'N', 'RECOMMENDED', 'example.com/image47.jpg'),
+('양산', 801, 100, 20, 'ACCESSORY', 'N', 'RECOMMENDED', 'example.com/image48.jpg'),
+('목도리', 804, 10, -100, 'ACCESSORY', 'N', 'RECOMMENDED', 'example.com/image49.jpg'),
+('플리스_모자', 801, 10, -10, 'ACCESSORY', 'N', 'REQUIRED', 'example.com/image50.jpg'),
+('자외선_차단제', 800, 100, 15, 'ACCESSORY', 'N', 'REQUIRED', 'example.com/image51.jpg'),
+('휴대용_선풍기', 800, 100, 20, 'ACCESSORY', 'N', 'SELECTION', 'example.com/image52.jpg'),
+('핫팩', 801, 5, -100, 'ACCESSORY', 'N', 'RECOMMENDED', 'example.com/image53.jpg'),
+('우산', 500, 100, -100, 'ACCESSORY', 'N', 'REQUIRED', 'example.com/image54.jpg'),
+('마스크', 804, 100, -100, 'ACCESSORY', 'N', 'REQUIRED', 'example.com/image55.jpg'),
+('비니', 800, 10, -100, 'ACCESSORY', 'N', 'RECOMMENDED', 'example.com/image56.jpg'),
+('손목시계', 800, 100, -100, 'ACCESSORY', 'N', 'SELECTION', 'example.com/image57.jpg'),
+('보조_배터리', 800, 100, -100, 'ACCESSORY', 'N', 'SELECTION', 'example.com/image58.jpg'),
+('손수건', 800, 100, -100, 'ACCESSORY', 'N', 'SELECTION', 'example.com/image59.jpg');
+
+INSERT INTO style (style_name) VALUES
+                                   ('casual'),   -- 1
+                                   ('formal'),   -- 2
+                                   ('sporty');   -- 3
+
+INSERT INTO outfit_style (outfit_seq, style_seq) VALUES
+-- 캐주얼 스타일
+(1, 1),    -- 맨투맨
+(2, 1),    -- 반팔 티셔츠
+(6, 1),    -- 폴로 반팔티
+(7, 1),    -- 나시
+(10, 1),   -- 터틀넥 스웨터
+(12, 1),   -- 긴청바지
+(13, 1),   -- 긴면바지
+(14, 1),   -- 반바지
+(16, 1),   -- 트레이닝 팬츠
+(24, 1),   -- 후드 집업
+(28, 1),   -- 바람막이
+(31, 1),   -- 운동화
+(32, 1),   -- 슬리퍼
+(39, 1),   -- 스니커즈
+(40, 1),   -- 크록스
+
+-- 포멀 스타일
+(3, 2),    -- 셔츠
+(5, 2),    -- 반팔셔츠
+(8, 2),    -- 터틀넥 스웨터
+(15, 2),   -- 슬랙스
+(21, 2),   -- 자켓
+(22, 2),   -- 코트
+(26, 2),   -- 트렌치코트
+(35, 2),   -- 로퍼
+(37, 2),   -- 플랫슈즈
+(38, 2),   -- 하이힐
+
+-- 스포티 스타일
+(7, 3),    -- 후드티
+(10, 3),   -- 나시
+(14, 3),   -- 반바지
+(16, 3),   -- 트레이닝 팬츠
+(17, 3),   -- 조거 팬츠
+(24, 3),   -- 후드 집업
+(31, 3),   -- 운동화
+(39, 3),   -- 스니커즈
+(40, 3);   -- 크록스
+
+INSERT INTO situation (situation_name) VALUES
+                                           ('daily'),    -- 1: 일상
+                                           ('travel'),   -- 2: 여행
+                                           ('exercise'), -- 3: 운동
+                                           ('couple'),   -- 4: 데이트
+                                           ('formal');   -- 5: 격식있는 자리
+
+INSERT INTO outfit_situation (outfit_seq, situation_seq) VALUES
+-- 일상 상황에 적합한 복장
+(1, 1),   -- 맨투맨
+(2, 1),   -- 반팔 티셔츠
+(4, 1),   -- 니트 스웨터
+(5, 1),   -- 후드티
+(6, 1),   -- 폴로 반팔티
+(10, 1),  -- 터틀넥 스웨터
+(12, 1),  -- 긴청바지
+(13, 1),  -- 긴면바지
+(14, 1),  -- 반바지
+(16, 1),  -- 트레이닝 팬츠
+(24, 1),  -- 후드 집업
+(31, 1),  -- 운동화
+(32, 1),  -- 슬리퍼
+(39, 1),  -- 스니커즈
+
+-- 여행 상황에 적합한 복장
+(1, 2),   -- 맨투맨
+(3, 2),   -- 셔츠
+(5, 2),   -- 후드티
+(8, 2),   -- 터틀넥 스웨터
+(12, 2),  -- 긴청바지
+(14, 2),  -- 반바지
+(20, 2),  -- 자켓
+(28, 2),  -- 바람막이
+(31, 2),  -- 운동화
+(39, 2),  -- 스니커즈
+
+-- 운동 상황에 적합한 복장
+(7, 3),   -- 후드티
+(10, 3),  -- 나시
+(14, 3),  -- 반바지
+(16, 3),  -- 트레이닝 팬츠
+(17, 3),  -- 조거 팬츠
+(24, 3),  -- 후드 집업
+(31, 3),  -- 운동화
+(39, 3),  -- 스니커즈
+(40, 3),  -- 크록스
+
+-- 데이트 상황에 적합한 복장
+(3, 4),   -- 셔츠
+(5, 4),   -- 반팔셔츠
+(6, 4),   -- 린넨셔츠
+(15, 4),  -- 슬랙스
+(22, 4),  -- 코트
+(26, 4),  -- 트렌치코트
+(35, 4),  -- 로퍼
+(38, 4),  -- 하이힐
+
+-- 격식있는 자리 상황에 적합한 복장
+(3, 5),   -- 셔츠
+(5, 5),   -- 반팔셔츠
+(8, 5),   -- 터틀넥 스웨터
+(15, 5),  -- 슬랙스
+(21, 5),  -- 자켓
+(22, 5),  -- 코트
+(26, 5),  -- 트렌치코트
+(35, 5),  -- 로퍼
+(37, 5),  -- 플랫슈즈
+(38, 5);  -- 하이힐

--- a/article1_be/article1-be/src/main/resources/data.sql
+++ b/article1_be/article1-be/src/main/resources/data.sql
@@ -62,11 +62,11 @@ INSERT INTO outfit (outfit_name, outfit_weather, outfit_temp_max, outfit_temp_mi
 ('휴대용_선풍기', 800, 100, 20, 'ACCESSORY', 'N', 'SELECTION', 'example.com/image52.jpg'),
 ('핫팩', 801, 5, -100, 'ACCESSORY', 'N', 'RECOMMENDED', 'example.com/image53.jpg'),
 ('우산', 500, 100, -100, 'ACCESSORY', 'N', 'REQUIRED', 'example.com/image54.jpg'),
-('마스크', 804, 100, -100, 'ACCESSORY', 'N', 'REQUIRED', 'example.com/image55.jpg'),
+('마스크', NULL, 100, -100, 'ACCESSORY', 'N', 'REQUIRED', 'example.com/image55.jpg'),
 ('비니', 800, 10, -100, 'ACCESSORY', 'N', 'RECOMMENDED', 'example.com/image56.jpg'),
-('손목시계', 800, 100, -100, 'ACCESSORY', 'N', 'SELECTION', 'example.com/image57.jpg'),
-('보조_배터리', 800, 100, -100, 'ACCESSORY', 'N', 'SELECTION', 'example.com/image58.jpg'),
-('손수건', 800, 100, -100, 'ACCESSORY', 'N', 'SELECTION', 'example.com/image59.jpg');
+('손목시계', NULL, 100, -100, 'ACCESSORY', 'N', 'SELECTION', 'example.com/image57.jpg'),
+('보조_배터리', NULL, 100, -100, 'ACCESSORY', 'N', 'SELECTION', 'example.com/image58.jpg'),
+('손수건', NULL, 100, -100, 'ACCESSORY', 'N', 'SELECTION', 'example.com/image59.jpg');
 
 INSERT INTO style (style_name) VALUES
                                    ('casual'),   -- 1


### PR DESCRIPTION
# 구현 완료된 내용
- 최고기온 , 최저기온, 날씨코드로 날씨 데이터에 맞는 각 카테고리별 복장요소 list 생성
- 생성된 복장요소에 선호 스타일, 상황에 맞는 요소에 점수 추가
- 악세사리의 경우 필요도에 대해 차등으로 점수 추가
- (예외) 공기질이 안좋은 경우엔 마스크에 +999점 추가 -> 가장 먼저 추천

# 추가로 구현해야하는 내용
- 유저 seq를 받아와 유저의 선호 스타일, 선택 기록, 체질에 맞게 알고리즘 요소 수정 및 추가
- 추천 후 선택된 내역 저장
- 요소별 재 추천 기능

close #6 